### PR TITLE
Add pickle

### DIFF
--- a/django_gzipping_cache/cache.py
+++ b/django_gzipping_cache/cache.py
@@ -1,4 +1,5 @@
 from django.core.cache import get_cache
+import pickle
 import zlib
 
 
@@ -14,13 +15,13 @@ class GzippingCache(object):
     def gzip(self, value):
         if not value:
             return None
-        return zlib.compress(value, self._compress_level)
+        return zlib.compress(pickle.dumps(value), self._compress_level)
 
     def ungzip(self, value):
         if not value:
             return None
         try:
-            return zlib.decompress(value)
+            return pickle.loads(zlib.decompress(value))
         except zlib.error:
             if self._pass_uncompressed:
                 return value

--- a/django_gzipping_cache/tests/test_django_gzipping_cache.py
+++ b/django_gzipping_cache/tests/test_django_gzipping_cache.py
@@ -5,6 +5,8 @@ with patch('django.conf.settings') as settings:
     settings.CACHES = {
         'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}
     }
+    settings.DEFAULT_CHARSET = 'utf-8'
+    from django.http import HttpResponse
     from ..cache import GzippingCache
 
 
@@ -61,3 +63,11 @@ class TestCacheFunctions(unittest.TestCase):
             self.underlying.get.return_value = stored_value
             end_value = self.cache.get('meta')
             self.assertEqual(start_value, end_value)
+
+    def test_round_trip_page(self):
+        start_value = HttpResponse(content="example")
+        self.cache.set('meta', start_value)
+        stored_value = self.underlying.set.call_args[0][1]
+        self.underlying.get.return_value = stored_value
+        end_value = self.cache.get('meta')
+        self.assertEqual(start_value.content, end_value.content)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-gzipping-cache',
-    version='0.1.0',
+    version='0.1.1',
     description='A wrapper for django caches that gzips cached values',
     long_description=open('README.rst').read(),
     author='MapMyFitness',
@@ -27,6 +27,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )


### PR DESCRIPTION
Following the lead of the filesystem cache, wrap pickle around the `set` / `get` methods for this cache. This allows full-page caching (and cacheing of other non-binary objects).
